### PR TITLE
Enable serving of default root object through CDN

### DIFF
--- a/retriever-poc-cloudfront.tf
+++ b/retriever-poc-cloudfront.tf
@@ -38,7 +38,7 @@ resource "aws_route53_record" "retriever_poc" {
 # Set up the CloudFront distribution.
 resource "aws_cloudfront_distribution" "retriever_poc" {
   origin {
-    domain_name = aws_s3_bucket_website_configuration.cloudx_json_bucket.website_endpoint
+    domain_name = aws_s3_bucket.cloudx_json_bucket.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
 
     # NOTE(mhayden): We need a custom origin config here so that Terraform

--- a/retriever-poc-s3.tf
+++ b/retriever-poc-s3.tf
@@ -11,13 +11,3 @@ resource "aws_s3_bucket_acl" "cloudx_json_bucket" {
   bucket = aws_s3_bucket.cloudx_json_bucket.id
   acl    = "private"
 }
-
-# Allow the bucket to host a website.
-resource "aws_s3_bucket_website_configuration" "cloudx_json_bucket" {
-  bucket = aws_s3_bucket.cloudx_json_bucket.bucket
-
-  index_document {
-    suffix = "index.json"
-  }
-}
-


### PR DESCRIPTION
**Why**
Currently we can't serve default root objects as defined in our CloudFront configuration (index.html) as it is conflicting with the S3 website endpoint (expects root object to be <root>/index.html).
As we are not serving data from an S3 website (we are using CloudFront to serve S3 data) we can drop the website configuration without impact. We will also be able to properly use the CloudFront default root object configuration to serve our web-app as well as our raw data index file (<root>/index.html for raw data, <root>/web-app/index.html for website).

**What changed**
Remove s3 website endpoint from S3 Terrafrom configuration