### PR TITLE
Remove custom origin config

### DIFF
--- a/retriever-poc-cloudfront.tf
+++ b/retriever-poc-cloudfront.tf
@@ -49,19 +49,6 @@ resource "aws_cloudfront_distribution" "retriever_poc" {
     s3_origin_config {
       origin_access_identity = aws_cloudfront_origin_access_identity.retriever_poc.cloudfront_access_identity_path
     }
-
-    # NOTE(mhayden): We need a custom origin config here so that Terraform
-    # doesn't explode when it tells CloudFront to use the website URL instead of
-    # the normal bucket URL. Using the website URL allows the default root/index
-    # functionality to work.
-    custom_origin_config {
-      http_port                = 80
-      https_port               = 443
-      origin_protocol_policy   = "http-only"
-      origin_ssl_protocols     = ["TLSv1.2"]
-      origin_keepalive_timeout = 5
-      origin_read_timeout      = 30
-    }
   }
 
   enabled             = true


### PR DESCRIPTION
This is no longer needed since we have an s3_origin_config. Leaving this here causes terraform to throw errors during the deployment.