### PR TITLE
Add CORS rule to get content

### DIFF
--- a/retriever-poc-s3.tf
+++ b/retriever-poc-s3.tf
@@ -27,6 +27,11 @@ data "aws_iam_policy_document" "read_cloudx_json_bucket" {
 # Create a bucket for the JSON files.
 resource "aws_s3_bucket" "cloudx_json_bucket" {
   bucket = "cloudx-json-bucket"
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+  }
 }
 
 # Add our CloudFront bucket policy.


### PR DESCRIPTION
As we are running a static website that will load data at runtime from this S3 data storage, we will need to allow CORS on GET requests.

I think that these headers still need to be forwarded by CloudFront but I'm not sure if it forwards those by default. Any insight on that?