### PR TITLE
Add CORS config to S3 bucket

### DIFF
--- a/retriever-poc-s3.tf
+++ b/retriever-poc-s3.tf
@@ -27,6 +27,11 @@ data "aws_iam_policy_document" "read_cloudx_json_bucket" {
 # Create a bucket for the JSON files.
 resource "aws_s3_bucket" "cloudx_json_bucket" {
   bucket = "cloudx-json-bucket"
+}
+
+# Add CORS to the bucket.
+resource "aws_s3_bucket_cors_configuration" "cloudx_json_bucket" {
+  bucket = aws_s3_bucket.cloudx_json_bucket.id
 
   cors_rule {
     allowed_methods = ["GET"]


### PR DESCRIPTION
The previous change in f012bdeee2c2b8131a688be6261778a768b2c750 didn't apply a CORS rule to the S3 bucket properly. It appears that the preferred method now is to use `aws_s3_bucket_cors_configuration`.