### PR TITLE
Add terraform resources to create staging environment

### DIFF
--- a/staging-cloudfront.tf
+++ b/staging-cloudfront.tf
@@ -1,0 +1,97 @@
+# CloudFront confuguration required for the staging environment
+locals {
+  s3_origin_id_staging          = "cid-staging"
+}
+
+# Set up an access identify for CloudFront. We use this in the S3 bucket policy so
+# CloudFront can read our private bucket content.
+resource "aws_cloudfront_origin_access_identity" "cid_staging" {
+  comment = "Access identity for CF to access private S3 bucket ${aws_s3_bucket.cid_bucket_staging.id}"
+}
+
+# Provision an automatically renewing certificate for the CloudFront
+# distribution.
+resource "aws_acm_certificate" "cid_staging" {
+  domain_name       = local.imagedirectory_domain
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Look up the AWS SimpleCORS policy.
+data "aws_cloudfront_response_headers_policy" "simple_cors_policy_staging" {
+  name = "Managed-SimpleCORS"
+}
+
+# Set up the CloudFront distribution.
+resource "aws_cloudfront_distribution" "cid_staging" {
+  origin {
+    domain_name = aws_s3_bucket.cid_bucket_staging.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.cid_staging.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "CDN for CID staging environment."
+  default_root_object = "index.html"
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cid_bucket_staging.bucket_domain_name
+    prefix          = "logs"
+  }
+
+  aliases = [local.imagedirectory_domain]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    # Use the SimpleCORS policy from AWS that allows all origins to access the data.
+    # TODO(mhayden): We might want to adjust this later to something more limited.
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.simple_cors_policy.id
+
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 31536000
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PriceClass.html
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.cid_staging.arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code = 404
+    response_code = 200
+    response_page_path = "/index.html"
+  }
+}

--- a/staging-front-end-iam.tf
+++ b/staging-front-end-iam.tf
@@ -1,0 +1,68 @@
+# This file is almost exactly the same as retriever-poc-iam.tf.
+# Even though permissions and roles are near identical,
+# the seperation of concerns is worth the slight code duplication.
+
+# IAM policy document for managing static website content in the bucket.
+data "aws_iam_policy_document" "push_static_front_end_staging" {
+  statement {
+    sid    = "PushStaticFrontEnd"
+    effect = "Allow"
+
+    actions = [
+      "s3:DeleteObjectTagging",
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetObjectAttributes",
+      "s3:GetObjectTagging",
+      "s3:ListBucket",
+      "s3:PutObjectTagging",
+      "s3:PutObjectAcl"
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.cid_bucket_staging.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.cid_bucket_staging.bucket}/*"
+    ]
+  }
+}
+
+# Load the IAM policy document into a policy that we can use with a role.
+resource "aws_iam_policy" "push_static_front_end_staging" {
+  name = "push_static_files"
+
+  policy = data.aws_iam_policy_document.push_static_front_end_staging.json
+}
+
+# IAM policy document that allows actions in the cloud-image-frontend repo to
+# assume the role.
+data "aws_iam_policy_document" "github_cloud_image_directory_frontend_staging" {
+  statement {
+    sid     = "GitHubActionsWebIdentityPolicy"
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:redhatcloudx/cloud-image-directory-frontend:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_cloud_image_directory_frontend_staging" {
+  name = "github_actions_cloud_image_directory_frontend_staging"
+
+  managed_policy_arns = [aws_iam_policy.push_static_front_end_staging.arn]
+  assume_role_policy  = data.aws_iam_policy_document.github_cloud_image_directory_frontend_staging.json
+}

--- a/staging-s3.tf
+++ b/staging-s3.tf
@@ -1,0 +1,51 @@
+# S3 configuration required to host the CID staging environment
+
+# Create a policy for the S3 bucket that allows CloudFront to read objects.
+data "aws_iam_policy_document" "read_cid_bucket_staging" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.cid_bucket_staging.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.retriever_poc.iam_arn]
+    }
+  }
+
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.cid_bucket_staging.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.retriever_poc.iam_arn]
+    }
+  }
+}
+
+# Create a bucket for the JSON files.
+resource "aws_s3_bucket" "cid_bucket_staging" {
+  bucket = "cloudx-json-bucket"
+}
+
+# Add CORS to the bucket.
+resource "aws_s3_bucket_cors_configuration" "cid_bucket_staging" {
+  bucket = aws_s3_bucket.cid_bucket_staging.id
+
+  cors_rule {
+    allowed_methods = ["GET"]
+    allowed_origins = ["*"]
+  }
+}
+
+# Add our CloudFront bucket policy.
+resource "aws_s3_bucket_policy" "cid_bucket_staging" {
+  bucket = aws_s3_bucket.cid_bucket_staging.id
+  policy = data.aws_iam_policy_document.read_cid_bucket_staging.json
+}
+
+# Set the bucket to private. We expose this bucket later via CloudFront.
+resource "aws_s3_bucket_acl" "cid_bucket_staging" {
+  bucket = aws_s3_bucket.cid_bucket_staging.id
+  acl    = "private"
+}


### PR DESCRIPTION
This PR enables the cid frontend repository to always deploy the newest changes to our staging environment on merge to main.

Add S3 bucket
Add CloudFront instance
Add IAM roles and policies for pushing the front-end