### PR TITLE
Fix resource duplication error on staging resource names

### DIFF
--- a/staging-cloudfront.tf
+++ b/staging-cloudfront.tf
@@ -51,7 +51,7 @@ resource "aws_cloudfront_distribution" "cid_staging" {
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
     cached_methods   = ["GET", "HEAD"]
-    target_origin_id = local.s3_origin_id
+    target_origin_id = local.s3_origin_id_staging
 
     forwarded_values {
       query_string = false

--- a/staging-front-end-iam.tf
+++ b/staging-front-end-iam.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "push_static_front_end_staging" {
 
 # Load the IAM policy document into a policy that we can use with a role.
 resource "aws_iam_policy" "push_static_front_end_staging" {
-  name = "push_static_files"
+  name = "push_static_files_to_staging"
 
   policy = data.aws_iam_policy_document.push_static_front_end_staging.json
 }


### PR DESCRIPTION
- Rename AWS policy for pushing static files to staging
- Change staging S3 target_origin_id to staging value