### PR TITLE
Add DNS record for staging environment

### DIFF
--- a/staging-cloudfront.tf
+++ b/staging-cloudfront.tf
@@ -1,6 +1,7 @@
 # CloudFront confuguration required for the staging environment
 locals {
   s3_origin_id_staging          = "cid-staging"
+  imagedirectory_domain_staging = "staging.imagedirectory.cloud"
 }
 
 # Set up an access identify for CloudFront. We use this in the S3 bucket policy so
@@ -12,12 +13,30 @@ resource "aws_cloudfront_origin_access_identity" "cid_staging" {
 # Provision an automatically renewing certificate for the CloudFront
 # distribution.
 resource "aws_acm_certificate" "cid_staging" {
-  domain_name       = local.imagedirectory_domain
+  domain_name       = local.imagedirectory_domain_staging
   validation_method = "DNS"
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+# Validate the certificate by creating a DNS record in Route 53.
+resource "aws_route53_record" "cid_staging" {
+  for_each = {
+    for dvo in aws_acm_certificate.cid_staging.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.imagedirectory_cloud.zone_id
 }
 
 # Look up the AWS SimpleCORS policy.
@@ -46,7 +65,7 @@ resource "aws_cloudfront_distribution" "cid_staging" {
     prefix          = "logs"
   }
 
-  aliases = [local.imagedirectory_domain]
+  aliases = [local.imagedirectory_domain_staging]
 
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD"]
@@ -63,7 +82,7 @@ resource "aws_cloudfront_distribution" "cid_staging" {
 
     # Use the SimpleCORS policy from AWS that allows all origins to access the data.
     # TODO(mhayden): We might want to adjust this later to something more limited.
-    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.simple_cors_policy.id
+    response_headers_policy_id = data.aws_cloudfront_response_headers_policy.simple_cors_policy_staging.id
 
     min_ttl                = 0
     default_ttl            = 86400
@@ -93,5 +112,22 @@ resource "aws_cloudfront_distribution" "cid_staging" {
     error_code = 404
     response_code = 200
     response_page_path = "/index.html"
+  }
+}
+
+# Add a DNS record for the CloudFront distribution.
+resource "aws_route53_record" "imagedirectory_frontend_staging" {
+  zone_id = data.aws_route53_zone.imagedirectory_cloud.zone_id
+  name    = local.imagedirectory_domain_staging
+  type    = "A"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  alias {
+    name                   = aws_cloudfront_distribution.cid_staging.domain_name
+    zone_id                = aws_cloudfront_distribution.cid_staging.hosted_zone_id
+    evaluate_target_health = false
   }
 }


### PR DESCRIPTION
Adding the configuration for the subdomain staging.imagedirectory.cloud.
@major please give it a thorough read to make sure I'm not missing anything.
I'd especially like to get your thought on the zone ocnfiguration:
`zone_id = data.aws_route53_zone.imagedirectory_cloud.zone_id`
From what I can tell the zone is reused and only the local domain name configuration use the 'imagedirectory_domain_staging' overwrite. What do you think?